### PR TITLE
Add support for checkip.dyndns.org

### DIFF
--- a/pubip.go
+++ b/pubip.go
@@ -15,6 +15,11 @@ import (
 	"github.com/jpillora/backoff"
 )
 
+const (
+	// DynDnsPrefix is the prefix used by the checkip.dyndns.org service.
+	DynDnsPrefix = "Current IP Address: "
+)
+
 // GetIPBy queries an API to retrieve a `net.IP` of this machine's public IP
 // address.
 //
@@ -66,6 +71,7 @@ func GetIPBy(dest string) (net.IP, error) {
 		}
 
 		tb := strings.TrimSpace(string(body))
+		tb = strings.TrimPrefix(tb, DynDnsPrefix) // trim the header if exists
 		ip := net.ParseIP(tb)
 		if ip == nil {
 			return nil, errors.New("IP address not valid: " + tb)

--- a/settings.go
+++ b/settings.go
@@ -23,6 +23,7 @@ var APIURIs = []string{
 	"http://wgetip.com",
 	"http://ip.appspot.com",
 	"http://ip.tyk.nu",
+	"http://checkip.dyndns.org/",
 	"https://shtuff.it/myip/short",
 }
 


### PR DESCRIPTION
Add a well-known service to the list. It has a prefix which we need to
strip.